### PR TITLE
Fix regression from invalid_url_fix

### DIFF
--- a/ksl_alert_frontend/src/components/AlertListings/AlertListings.js
+++ b/ksl_alert_frontend/src/components/AlertListings/AlertListings.js
@@ -16,7 +16,7 @@ class AlertListings extends Component {
     // using request library to get url(s) from our user database with specific user id
     request(this.props.url, (error, response, body) => {
       // Check if the request was successful
-      if (body && response.code === 200) {
+      if (body && response.statusCode === 200) {
         const $ = cheerio.load(body); // Pass the request body to cheerio for web scraping
 
         // The data we need exists within 'window.renderSearchSection()' inside a <script> tag (discovered by inspecting page source)


### PR DESCRIPTION
# Description

Fix for a typo in the `if` condition that was causing the AlertListings component to render valid URL's as error messages.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings