### PR TITLE
Fix: unique 'key' warnings when rendering component lists

### DIFF
--- a/ksl_alert_frontend/src/components/AlertFeed/AlertFeed.js
+++ b/ksl_alert_frontend/src/components/AlertFeed/AlertFeed.js
@@ -31,7 +31,7 @@ export default class AlertFeed extends Component {
           <h2>Alert Feed</h2>
           {this.state.queries ? (
             this.state.queries.map(query => (
-              <Segment>
+              <Segment key={query._id}>
                 <AlertCard query={query} />
               </Segment>
             ))

--- a/ksl_alert_frontend/src/components/AlertListings/AlertListings.js
+++ b/ksl_alert_frontend/src/components/AlertListings/AlertListings.js
@@ -59,6 +59,7 @@ class AlertListings extends Component {
             this.state.listings.map(listing => {
               return (
                 <ListingCard
+                  key={listing.createTime}
                   price={listing.price}
                   city={listing.city}
                   createdOn={listing.createTime}


### PR DESCRIPTION
# Description
Fix: unique 'key' warnings in React elements rendering of list components

Fixes # (issue)
Add unique key to AlertFeed's rendering list of Segment/AlertCards
Add unique key to AlertListing's rendering list of ListingCards

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested via browser to see that warnings were fixed and removed from the console

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
