### PR TITLE
Toggle query alert listings

### DIFF
--- a/ksl_alert_frontend/src/components/AlertCard/AlertCard.js
+++ b/ksl_alert_frontend/src/components/AlertCard/AlertCard.js
@@ -1,14 +1,28 @@
-import React from 'react';
+import React, { Component } from 'react';
 import AlertListings from '../AlertListings/AlertListings.js';
 
 // receiving query props from AlertFeed
-const AlertCard = props => {
-  return (
-    <div>
-      <h4>Query: {props.query.title}</h4>
-      <AlertListings url={props.query.url} />
-    </div>
-  );
+class AlertCard extends Component {
+  constructor(props) {
+    super(props);
+  };
+
+  state = {
+    displayListings: false
+  };
+
+  toggleListings = () => {
+    this.setState({ displayListings: !this.state.displayListings });
+  };
+
+  render() {
+    return (
+      <div onClick={this.toggleListings} style={{cursor:'pointer'}}>
+        <h4>Query: {this.props.query.title}</h4>
+        <AlertListings url={this.props.query.url} displayListings={this.state.displayListings}/>
+      </div>
+    );
+  };
 };
 
 export default AlertCard;

--- a/ksl_alert_frontend/src/components/AlertListings/AlertListings.js
+++ b/ksl_alert_frontend/src/components/AlertListings/AlertListings.js
@@ -49,28 +49,32 @@ class AlertListings extends Component {
   }
 
   render() {
-    return (
-      <div>
-        {// If there is an err, render the error message
-        // Else, iterate of this.state.listings
-          this.state.err ? (
-            <p>{this.state.err}</p>
-          ) : (
-            this.state.listings.map(listing => {
-              return (
-                <ListingCard
-                  key={listing.createTime}
-                  price={listing.price}
-                  city={listing.city}
-                  createdOn={listing.createTime}
-                  photo={listing.photo}
-                />
-              );
-            })
-          )}
-      </div>
-    );
-  }
+    if (!this.props.displayListings) {
+      return null;
+    } else {
+      return (
+        <div>
+          {// If there is an err, render the error message
+          // Else, iterate of this.state.listings
+            this.state.err ? (
+              <p>{this.state.err}</p>
+            ) : (
+              this.state.listings.map(listing => {
+                return (
+                  <ListingCard
+                    key={listing.createTime}
+                    price={listing.price}
+                    city={listing.city}
+                    createdOn={listing.createTime}
+                    photo={listing.photo}
+                  />
+                );
+              })
+            )}
+        </div>
+      );
+    }
+  };
 }
 
 export default AlertListings;


### PR DESCRIPTION
# Description
Add ability to toggle the displaying of alert listings on and off per each alert card

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested toggling via localhost browser by clicking alert cards

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
