### PR TITLE
Add  deleteQuery API endpoint

### DIFF
--- a/ksl_alert_backend/user/userController.js
+++ b/ksl_alert_backend/user/userController.js
@@ -1,4 +1,3 @@
-//user route middleware
 const router = require('express').Router();
 const jwt = require('jsonwebtoken');
 const User = require('./userModel.js');
@@ -6,9 +5,13 @@ const User = require('./userModel.js');
 //for .env file to save sensitive info
 require('dotenv').config();
 
+// Used to generate a JWT token
 const secret = process.env.SECRET;
 
-// middlewares
+/**
+ * Middlware
+ */
+
 // generate token for the login
 const generateToken = user => {
   const options = {
@@ -38,16 +41,10 @@ const restrictedRoute = (req, res, next) => {
   }
 };
 
-// functions that will pass to each endpoints
-const getAllUsers = (req, res) => {
-  User.find()
-    .then(users => {
-      res.status(200).json(users);
-    })
-    .catch(err => {
-      res.status(500).json({ errorMessage: 'Error fetching users' });
-    });
-};
+
+/**
+ * DB Queries
+ */
 
 // get user by ID
 const getUserById = (req, res) => {
@@ -65,6 +62,7 @@ const getUserById = (req, res) => {
     });
 };
 
+// sign up a new User
 const signUp = (req, res) => {
   const { email, password } = req.body;
   const newUser = new User({ email, password });
@@ -158,7 +156,7 @@ const saveQuery = (req, res) => {
     });
 };
 
-// update User's password
+// update a User's password
 const updatePassword = (req, res) => {
   const { id, currentPassword, newPassword } = req.body;
 
@@ -179,7 +177,7 @@ const updatePassword = (req, res) => {
   });
 };
 
-// update User's email
+// update a User's email
 const updateEmail = (req, res) => {
   const { newEmail, id } = req.body;
   User.findByIdAndUpdate(id, { email: newEmail }, { new: true })
@@ -192,24 +190,27 @@ const deleteQuery = (req, res) => {
   const { id, queryId } = req.body;
   User.findById(id)
     .then(user => {
-      updatedQueries = user.queries.filter(query => query._id != queryId)
+      updatedQueries = user.queries.filter(query => query._id != queryId);
       User.findByIdAndUpdate(id, { queries: updatedQueries }, { new: true })
         .then(user => res.status(200).json(user))
-        .catch(err => res.status(500).json(err))
+        .catch(err => res.status(500).json(err));
     })
-    .catch(err => res.status(500).json(err))
-}
+    .catch(err => res.status(500).json(err));
+};
 
-// refactor routes endpoints
-router.route('/').get(restrictedRoute, getAllUsers);
+/**
+ * Endpoints
+ */
+
+// routes that don't require a token in header
 router.route('/signUp').post(signUp);
 router.route('/signIn').post(signIn);
+
+// routes that require an id sent in request and token in header
+router.route('/getUser').post(restrictedRoute, getUserById);
 router.route('/updatePassword').put(restrictedRoute, updatePassword);
 router.route('/updateEmail').put(restrictedRoute, updateEmail);
-
-// route that require ID
-router.route('/getUser').post(restrictedRoute, getUserById);
-router.route('/saveQuery').put(saveQuery);
-router.route('/deleteQuery').put(deleteQuery);
+router.route('/saveQuery').put(saveQuery); // TODO: Insert middleware
+router.route('/deleteQuery').put(deleteQuery); // TODO: Insert middleware
 
 module.exports = router;

--- a/ksl_alert_backend/user/userController.js
+++ b/ksl_alert_backend/user/userController.js
@@ -189,11 +189,11 @@ const updateEmail = (req, res) => {
 
 // delete a User's query
 const deleteQuery = (req, res) => {
-  const { userId, queryId } = req.body;
-  User.findById(userId)
+  const { id, queryId } = req.body;
+  User.findById(id)
     .then(user => {
       updatedQueries = user.queries.filter(query => query._id != queryId)
-      User.findByIdAndUpdate(userId, { queries: updatedQueries }, { new: true })
+      User.findByIdAndUpdate(id, { queries: updatedQueries }, { new: true })
         .then(user => res.status(200).json(user))
         .catch(err => res.status(500).json(err))
     })

--- a/ksl_alert_backend/user/userController.js
+++ b/ksl_alert_backend/user/userController.js
@@ -187,6 +187,19 @@ const updateEmail = (req, res) => {
     .catch(error => res.status(500).json(error));
 };
 
+// delete a User's query
+const deleteQuery = (req, res) => {
+  const { userId, queryId } = req.body;
+  User.findById(userId)
+    .then(user => {
+      updatedQueries = user.queries.filter(query => query._id != queryId)
+      User.findByIdAndUpdate(userId, { queries: updatedQueries }, { new: true })
+        .then(user => res.status(200).json(user))
+        .catch(err => res.status(500).json(err))
+    })
+    .catch(err => res.status(500).json(err))
+}
+
 // refactor routes endpoints
 router.route('/').get(restrictedRoute, getAllUsers);
 router.route('/signUp').post(signUp);
@@ -197,5 +210,6 @@ router.route('/updateEmail').put(restrictedRoute, updateEmail);
 // route that require ID
 router.route('/getUser').post(restrictedRoute, getUserById);
 router.route('/saveQuery').put(saveQuery);
+router.route('/deleteQuery').put(deleteQuery);
 
 module.exports = router;


### PR DESCRIPTION
# Description

Add an API endpoint for deleting a user's query. Requires the `userId` and `queryId` to be sent in the body of a PUT request to `/api/user/deleteQuery`. Returns the updated `User` object on success.

TODO: Insert `restrictedRoute` middleware so it requires a valid token to access.

NOTE: This is probably not the most efficient way to do this. The better way would likely involve adding another a `Query` schema and storing them on the `User` as subdocuments so you can use [MongooseArray.pull()](https://devdocs.io/mongoose/api#types_array_MongooseArray.pull). This implementation does seem to work though.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally with Postman.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings